### PR TITLE
fix: dimming padded bits

### DIFF
--- a/src/expression/components/BitwiseResultView.tsx
+++ b/src/expression/components/BitwiseResultView.tsx
@@ -16,7 +16,7 @@ type BitwiseResultViewProps = {
     expression: Expression;
     emphasizeBytes: boolean;
     annotateTypes: boolean,
-    dimExtrBits: boolean
+    dimExtraBits: boolean
 }
 
 type BitwiseResultViewState = {
@@ -50,7 +50,7 @@ export default class BitwiseResultView extends React.Component<BitwiseResultView
 
         let css = "expression";
 
-        if(this.props.dimExtrBits)
+        if(this.props.dimExtraBits)
             css += " dim-extra-bits";
 
         return <React.Fragment>
@@ -122,7 +122,7 @@ class ExpressionElementTableRow extends React.Component<ExpressionElementRowProp
         const scalar = this.props.expressionItem.evaluate();
         const bin = formatter.numberToString(scalar.value, 'bin', maxNumberOfBits);
         const signBitIndex = scalar.value.signed && bin.length >= scalar.value.maxBitSize ? bin.length - scalar.value.maxBitSize : -1;
-        const valueSize = annotateTypes ? scalar.value.maxBitSize : calc.numberOfBitsDisplayed(scalar.value);
+        const valueSize = calc.numberOfBitsDisplayed(scalar.value);
 
         return <tr className={"row-with-bits " + css}>
             <td className="sign">{sign}</td>

--- a/src/expression/components/BitwiseResultViewModel.ts
+++ b/src/expression/components/BitwiseResultViewModel.ts
@@ -58,7 +58,7 @@ export default class BitwiseResultViewModel {
 
             const eo = ex as Operator;
 
-            // If it a single NOT expression
+            // If it is a single NOT expression
             if(eo.isNotExpression) {
                 m.addOperatorRow(eo);
                 const notResult = eo.evaluate();

--- a/src/expression/module.tsx
+++ b/src/expression/module.tsx
@@ -12,7 +12,7 @@ const expressionAppModule = {
             canHandle: (input:string) => parser.canParse(input),
             handle: function(c: CommandInput) {
                 var expr = parser.parse(c.input);
-                appState.addCommandResult(c.input, () => <BitwiseResultView expression={expr!} emphasizeBytes={appState.emphasizeBytes} annotateTypes={appState.annotateTypes} dimExtrBits={appState.dimExtraBits} />);
+                appState.addCommandResult(c.input, () => <BitwiseResultView expression={expr!} emphasizeBytes={appState.emphasizeBytes} annotateTypes={appState.annotateTypes} dimExtraBits={appState.dimExtraBits} />);
             }
         });
     }

--- a/src/shell/AppState.ts
+++ b/src/shell/AppState.ts
@@ -7,10 +7,10 @@ export type PersistedAppData = {
     uiTheme: string;
     version: number | null;
     debugMode: boolean | null;
-    pageVisistsCount: number;
+    pageVisitsCount: number;
     donationClicked: boolean;
     annotateTypes: boolean;
-    dimExtrBits: boolean;
+    dimExtraBits: boolean;
     cookieDisclaimerHidden: boolean,
     centeredLayout?: boolean
 }
@@ -54,10 +54,10 @@ export default class AppState {
         this.persistedVersion = persistData.version || 0.1;
         this.wasOldVersion = persistData.version !== null && persistData.version !== undefined && this.version > this.persistedVersion;
         this.debugMode = persistData.debugMode === true;
-        this.pageVisitsCount = persistData.pageVisistsCount || 0;
+        this.pageVisitsCount = persistData.pageVisitsCount || 0;
         this.donationClicked = persistData.donationClicked;
         this.annotateTypes = !!persistData.annotateTypes;
-        this.dimExtraBits = !!persistData.dimExtrBits;
+        this.dimExtraBits = !!persistData.dimExtraBits;
         this.cookieDisclaimerHidden = !!persistData.cookieDisclaimerHidden
         this.centeredLayout = (persistData.centeredLayout === undefined) ? true : !!persistData.centeredLayout;
     }
@@ -121,7 +121,7 @@ export default class AppState {
         this.triggerChanged('annotateTypes');
     }
 
-    toggleDimExtrBits() {
+    toggleDimExtraBits() {
         this.dimExtraBits = !this.dimExtraBits;
         this.triggerChanged('dimExtraBits');
     }
@@ -155,10 +155,10 @@ export default class AppState {
             uiTheme: this.uiTheme,
             version: this.version,
             debugMode: this.debugMode,
-            pageVisistsCount: this.pageVisitsCount,
+            pageVisitsCount: this.pageVisitsCount,
             donationClicked: this.donationClicked,
             annotateTypes: this.annotateTypes,
-            dimExtrBits: this.dimExtraBits,
+            dimExtraBits: this.dimExtraBits,
             cookieDisclaimerHidden: this.cookieDisclaimerHidden,
             centeredLayout: this.centeredLayout
         }

--- a/src/shell/appStateStore.ts
+++ b/src/shell/appStateStore.ts
@@ -7,10 +7,10 @@ const DEFAULT_DATA : PersistedAppData = {
     emphasizeBytes: false,
     version: APP_VERSION,
     debugMode: false,
-    pageVisistsCount: 0,
+    pageVisitsCount: 0,
     donationClicked: false,
     annotateTypes: false,
-    dimExtrBits: false,
+    dimExtraBits: false,
     cookieDisclaimerHidden: false,
     centeredLayout: true
 }

--- a/src/shell/components/SettingsPane.tsx
+++ b/src/shell/components/SettingsPane.tsx
@@ -25,7 +25,7 @@ function SettingsPane(props : SettingsPaneProps) {
                 </p>
             </div>
             <div className='setting'>
-                <button type="button" onClick={() => appState.toggleDimExtrBits()}>
+                <button type="button" onClick={() => appState.toggleDimExtraBits()}>
                     <FontAwesomeIcon size='xl' icon={appState.dimExtraBits ? faToggleOn : faToggleOff} /> Dim Padding Bits
                 </button>
                 <p className='description'>


### PR DESCRIPTION
This PR intends on fixing the dimming of the padded bits, when annotated data types is enabled.

The feature in the bitwise calculator failed to dim padded bits when "Annotate Data Types" was enabled, but worked correctly when it was disabled. This happened because the dimming logic relied on a `valueBitSize` that switched sources: using the minimal displayed bits when annotation was off (creating many "extra" bits) versus the full declared bit width (`maxBitSize`) when annotation was on (often resulting in no extra bits). The interference made the two features incompatible, unintentionally effectively disabling dimming in the annotated mode.

This change makes it so that it always uses the number's declared bit width (`maxBitSize`) to determine which padded bits are "extra" and should be dimmed, instead of switching based on whether type annotation is enabled.

<details>
  <summary>Before & after</summary>

Before
<img width="855" height="430" alt="image" src="https://github.com/user-attachments/assets/89821f84-8864-4cc6-a99a-104d72c8d6ac" />
After
<img width="855" height="430" alt="image" src="https://github.com/user-attachments/assets/04fae6f7-6da1-4b2b-8ec8-95138274e23b" />
  
</details>


Misspelled variables and comment grammar were also corrected. 
These changes were separated to their own commit, in case you'd like to cherry pick commits.